### PR TITLE
Fix CRL reason code mapping

### DIFF
--- a/lib/Crypt/X509/CRL.pm
+++ b/lib/Crypt/X509/CRL.pm
@@ -500,9 +500,18 @@ sub _IDP_rdn {
 # revocation_list
 sub revocation_list {
     my $self = shift;
-    my @crl_reason = qw(unspecified keyCompromise cACompromise affiliationChanged superseded
-    			cessationOfOperation certificateHold removeFromCRL privilegeWithdrawn
-    			aACompromise);
+    my %crl_reason = (
+            0  => 'unspecified',
+            1  => 'keyCompromise',
+            2  => 'cACompromise',
+            3  => 'affiliationChanged',
+            4  => 'superseded',
+            5  => 'cessationOfOperation',
+            6  => 'certificateHold',
+            8  => 'removeFromCRL',
+            9  => 'privilegeWithdrawn',
+            10 => 'aACompromise',
+            );
     my %hold_codes = (
 	    '1.2.840.10040.2.1' => 'holdinstruction-none',
 	    '1.2.840.10040.2.2' => 'holdinstruction-callissuer',
@@ -542,7 +551,7 @@ sub revocation_list {
                     return undef;
                 }
                 $self->{'tbsCertList'}{'rl'}{ $rl->{'userCertificate'} }{'crlReason'} =
-                                                        $crl_reason[ $reason ];
+                                                        $crl_reason{ $reason };
 
             } elsif ( $extension->{'extnID'} eq '2.5.29.24' ) { # OID for invalidityDate
                 my $parser = _init('invalidityDate');


### PR DESCRIPTION
This fixes incorrect mapping of the following CRL reason codes:

 - removeFromCRL (7 -> 8)
 - privilegeWithdrawn (8 -> 9)
 - aACompromise (9 -> 10)

RFC 5280 section 5.3.1 [1] lists the reason codes as:

```
   CRLReason ::= ENUMERATED {
        unspecified             (0),
        keyCompromise           (1),
        cACompromise            (2),
        affiliationChanged      (3),
        superseded              (4),
        cessationOfOperation    (5),
        certificateHold         (6),
             -- value 7 is not used
        removeFromCRL           (8),
        privilegeWithdrawn      (9),
        aACompromise           (10) }
```

[1] https://datatracker.ietf.org/doc/html/rfc5280#section-5.3.1